### PR TITLE
Composed media queries should use an 'and' between the existing media query and the 2x queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var query = [
   '(min-device-pixel-ratio: 1.5)',
   '(min-resolution: 144dpi)',
   '(min-resolution: 1.5dppx)'
-].join(', ');
+];
 
 /**
  * Translate
@@ -77,7 +77,7 @@ module.exports = function() {
         // wrap in @media
         style.rules.push({
           type: 'media',
-          media: (basequery ? basequery + ', ' : '') + query,
+          media: (basequery ? combineMediaQuery(basequery.split(/,\s*/), query) : query.join(', ')),
           rules: [
             {
               type: 'rule',
@@ -101,6 +101,20 @@ module.exports = function() {
     });
   };
 };
+
+
+/**
+ * Combines existing media query with 2x media query.
+ */
+function combineMediaQuery(base, additional) {
+  var finalQuery = [];
+  base.forEach(function(b) {
+    additional.forEach(function(a) {
+      finalQuery.push(b + ' and ' + a);
+    });
+  });
+  return finalQuery.join(', ');
+}
 
 /**
  * Filter background[-image] with url().

--- a/test/fixtures/at2x.out.css
+++ b/test/fixtures/at2x.out.css
@@ -31,7 +31,7 @@
   }
 }
 
-@media (min-width: 200px), (max-width: 400px), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (-webkit-min-device-pixel-ratio: 1.5), (min-device-pixel-ratio: 1.5), (min-resolution: 144dpi), (min-resolution: 1.5dppx) {
+@media (min-width: 200px) and (min--moz-device-pixel-ratio: 1.5), (min-width: 200px) and (-o-min-device-pixel-ratio: 3/2), (min-width: 200px) and (-webkit-min-device-pixel-ratio: 1.5), (min-width: 200px) and (min-device-pixel-ratio: 1.5), (min-width: 200px) and (min-resolution: 144dpi), (min-width: 200px) and (min-resolution: 1.5dppx), (max-width: 400px) and (min--moz-device-pixel-ratio: 1.5), (max-width: 400px) and (-o-min-device-pixel-ratio: 3/2), (max-width: 400px) and (-webkit-min-device-pixel-ratio: 1.5), (max-width: 400px) and (min-device-pixel-ratio: 1.5), (max-width: 400px) and (min-resolution: 144dpi), (max-width: 400px) and (min-resolution: 1.5dppx) {
   .logo {
     background-image: url("/public/images/logo@2x.png");
     background-size: contain;


### PR DESCRIPTION
For:

``` css
@media only screen and (min-width: 48em) {
   /** at-2x image here that's specific for larger screens. */
}
```

...we currently get something like:

``` css
@media only screen and (min-width: 48em), (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi), (min-resolution: 1.5dppx) {
  ...
}
```

...which messes up the image for smaller retina screens.

The output we want is actually:

``` css
@media only screen and (min-width: 48em) and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-width: 48em) and (min-resolution: 144dpi), only screen and (min-width: 48em) and (min-resolution: 1.5dppx) {
  ...
}
```

...or better visualized as:

``` css
@media
  only screen and (min-width: 48em) and (-webkit-min-device-pixel-ratio: 1.5),
  only screen and (min-width: 48em) and (min-resolution: 144dpi),
  only screen and (min-width: 48em) and (min-resolution: 1.5dppx) {
    ...
}
```

(Commas are like `OR` and `and` is like `AND`, which is what we want here.)
